### PR TITLE
fix pip version to 24.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - pip
+  - pip=24.0
   - python=3.9.6
   - pip:
     - torch


### PR DESCRIPTION
Newer version of pip will have issue during installation 

```
Pip subprocess error:
WARNING: Ignoring version 1.8.1 of pytorch-lightning since it has invalid metadata:
Requested pytorch-lightning==1.8.1 from https://files.pythonhosted.org/packages/54/8f/ff9e74724d1c203e8f1efe4b763ef941as
    torch (>=1.9.*)
           ~~~~~~^
Please use pip<24.1 if you need to use this version.
```